### PR TITLE
Elastic net paths did not uncompress the glmnet indices

### DIFF
--- a/glmnet/elastic_net.py
+++ b/glmnet/elastic_net.py
@@ -11,17 +11,19 @@ class ElasticNet(object):
         self.rsquared_ = None
 
     def fit(self, X, y):
-        n_lambdas, intercept_, coef_, _, _, rsquared_, lambdas, _, jerr \
+        n_lambdas, intercept_, ca, ia_, nin_, rsquared_, lambdas, _, jerr \
         = elastic_net(X, y, self.rho, lambdas=[self.alpha])
         # elastic_net will fire exception instead
         # assert jerr == 0
-        self.coef_ = coef_
+        nin_ = nin_[0]
+        self.coef_ = ca[:nin_]
+        self.indices_ = ia_[:nin_] - 1
         self.intercept_ = intercept_
         self.rsquared_ = rsquared_
         return self
 
     def predict(self, X):
-        return np.dot(X, self.coef_) + self.intercept_
+        return np.dot(X[:,self.indices_], self.coef_) + self.intercept_
 
     def __str__(self):
         n_non_zeros = (np.abs(self.coef_) != 0).sum()
@@ -32,12 +34,33 @@ class ElasticNet(object):
                  n_non_zeros / float(len(self.coef_)) * 100,
                  self.intercept_[0], self.alpha, self.rsquared_[0])
 
-
 def elastic_net_path(X, y, rho, **kwargs):
-    """return full path for ElasticNet"""
-    n_lambdas, intercepts, coefs, _, _, _, lambdas, _, jerr \
-    = elastic_net(X, y, rho, **kwargs)
-    return lambdas, coefs, intercepts
+    """return full path for ElasticNet
+    
+    Inputs:
+    -------
+    X -- a (samples, variables) ndarray
+    y -- a (sample, 1) ndarray
+    rho -- balance between ridge (0) and lasso (1) regression
+    
+    Outputs:
+    --------
+    lambdas    -- (n,) list of lambdas for which a model was generated
+    coefs      -- (variables,n) uncompressed coefficients.
+    intercepts -- (n,) intercepts
+    """
+    # The returned indices are compressed. 
+    # permutation is the forward mapping. this is a single row (even if we have multiple alphas)
+    # then cins specifies how many of them we want to use. This is a value for each tested lambda
+    n_lambdas, intercepts, compressed_coefs, permutation, cin, _, lambdas, _, jerr = elastic_net(X, y, rho, **kwargs)
+    permutation=permutation-1
+    w=compressed_coefs.shape[1]
+    uncompressed_coefs=np.zeros((X.shape[1],w))
+    for c in range(0,w):
+        upto=cin[c]
+        indices=permutation[:upto]
+        uncompressed_coefs[indices,c]=compressed_coefs[:upto,c]
+    return lambdas, uncompressed_coefs, intercepts 
 
 def Lasso(alpha):
     """Lasso based on GLMNET"""
@@ -46,3 +69,4 @@ def Lasso(alpha):
 def lasso_path(X, y, **kwargs):
     """return full path for Lasso"""
     return elastic_net_path(X, y, rho=1.0, **kwargs)
+

--- a/glmnet/glmnet.py
+++ b/glmnet/glmnet.py
@@ -94,7 +94,7 @@ def elastic_net(predictors, target, balance, memlimit=None,
     # Call the Fortran wrapper.
     lmu, a0, ca, ia, nin, rsq, alm, nlp, jerr =  \
             _glmnet.elnet(balance, predictors, target, weights, jd, vp,
-                          memlimit, flmin, ulam, thr, nlam=nlam)
+                          memlimit, flmin, ulam, thr, nlam=nlam, isd=isd)
     
     # Check for errors, documented in glmnet.f.
     if jerr != 0:


### PR DESCRIPTION
Hello,

I'm new to github, so I hope I follow the correct channel. Attached a patch that solves a bug in the ElasticNet.py file. In particular, the glmnets returns compressed indices, yet these were not used. Although that doesn't matter when just plotting graphs, it does matter if we try to use the returned models as a predictor. Therefore it is necessary to decompress the coefficients before returning them.

Secondly, the ElasticNet predictor object itself was also blissfully unaware of the indices.

This patch solves these two problems
With kind regards,

Werner,-
